### PR TITLE
getRandomObjectsWithParams:bound:completion:

### DIFF
--- a/BaasBox-iOS-SDK/BAAObject.m
+++ b/BaasBox-iOS-SDK/BAAObject.m
@@ -258,11 +258,11 @@
 
 + (void) getRandomObjectsWithParams:(NSDictionary *)parameters bound:(NSInteger)bound completion:(BAAArrayResultBlock)completionBlock {
     
-    [[self class] getObjectsWithParams:parameters completion:^(NSArray *objects, NSError *error) {
+    if (completionBlock) {
         
-        if (error == nil) {
+        [[self class] getObjectsWithParams:parameters completion:^(NSArray *objects, NSError *error) {
             
-            if (completionBlock) {
+            if (error == nil) {
                 
                 if (bound > objects.count) {
                     
@@ -285,19 +285,13 @@
                     
                 }
                 
-            }
-            
-        } else {
-            
-            if (completionBlock) {
+            } else {
                 
                 completionBlock(nil, error);
                 
             }
-        }
-        
-    }];
-    
+        }];
+    }
 }
 
 @end


### PR DESCRIPTION
Moving the check for the completion block to the top. There’s no use
continuing (no possible way to return the objects) if there’s no
completion block.
