### PR TITLE
Simulator Push Notifications

### DIFF
--- a/BaasBox-iOS-SDK/BAAClient.m
+++ b/BaasBox-iOS-SDK/BAAClient.m
@@ -1144,31 +1144,35 @@ NSString* const BAAUserKeyForUserDefaults = @"com.baaxbox.user";
 #pragma mark - Push notifications
 
 - (void) askToEnablePushNotifications {
-  
-#if TARGET_OS_IPHONE
-  
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < 80000
-  
-  [[UIApplication sharedApplication] registerForRemoteNotificationTypes:
-   (UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert)];
-  
-#else
-  
-  UIUserNotificationSettings *settings =
-  [UIUserNotificationSettings settingsForTypes:UIUserNotificationTypeAlert |UIUserNotificationTypeBadge |  UIUserNotificationTypeSound
-                                    categories:nil];
-  [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
-  [[UIApplication sharedApplication] registerForRemoteNotifications];
-  
+    
+#if !(TARGET_IPHONE_SIMULATOR)
+    
+    #if TARGET_OS_IPHONE
+    
+        #if __IPHONE_OS_VERSION_MIN_REQUIRED < 80000
+    
+            [[UIApplication sharedApplication] registerForRemoteNotificationTypes:
+            (UIRemoteNotificationTypeBadge | UIRemoteNotificationTypeSound | UIRemoteNotificationTypeAlert)];
+    
+        #else
+    
+            UIUserNotificationSettings *settings =
+            [UIUserNotificationSettings settingsForTypes:UIUserNotificationTypeAlert |UIUserNotificationTypeBadge |  UIUserNotificationTypeSound
+                                      categories:nil];
+            [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+            [[UIApplication sharedApplication] registerForRemoteNotifications];
+    
+        #endif
+    
+    #else
+    
+        [[NSApplication sharedApplication] registerForRemoteNotificationTypes:
+        (NSRemoteNotificationTypeBadge | NSRemoteNotificationTypeSound | NSRemoteNotificationTypeAlert)];
+    
+    #endif
+
 #endif
-  
-#else
-  
-  [[NSApplication sharedApplication] registerForRemoteNotificationTypes:
-   (NSRemoteNotificationTypeBadge | NSRemoteNotificationTypeSound | NSRemoteNotificationTypeAlert)];
-  
-#endif
-  
+
 }
 
 - (void) enablePushNotifications:(NSData *)tokenData completion:(BAABooleanResultBlock)completionBlock {


### PR DESCRIPTION
Allows using the simulator for testing when push notifications are
used. The simulator can’t receive notifications but it can send them.
