### PR TITLE
Update to BAAClient.m to avoid crashing

### DIFF
--- a/BaasBox-iOS-SDK/BAAClient.m
+++ b/BaasBox-iOS-SDK/BAAClient.m
@@ -1480,7 +1480,10 @@ NSString* const BAAUserKeyForUserDefaults = @"com.baaxbox.user";
     
     [[self.session dataTaskWithRequest:request
                      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                         
+                         if(response == nil){
+                         	failure(error);
+                         	return;
+                         }
                          NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)response;
                          NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:data
                                                                                     options:kNilOptions
@@ -1530,7 +1533,10 @@ NSString* const BAAUserKeyForUserDefaults = @"com.baaxbox.user";
     
 	[[self.session dataTaskWithRequest:request
                      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                         
+                         if(response == nil){
+                         	failure(error);
+                         	return;
+                         }                         
                          NSHTTPURLResponse *r = (NSHTTPURLResponse*)response;
                          NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:data
                                                                                     options:kNilOptions
@@ -1570,7 +1576,10 @@ NSString* const BAAUserKeyForUserDefaults = @"com.baaxbox.user";
                                                  parameters:parameters];
     [[self.session dataTaskWithRequest:request
                      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                         
+                         if(response == nil){
+                         	failure(error);
+                         	return;
+                         }                         
                          NSHTTPURLResponse *r = (NSHTTPURLResponse*)response;
                          NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:data
                                                                                     options:kNilOptions
@@ -1610,7 +1619,10 @@ NSString* const BAAUserKeyForUserDefaults = @"com.baaxbox.user";
                                                  parameters:parameters];
     [[self.session dataTaskWithRequest:request
                      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                         
+                         if(response == nil){
+                         	failure(error);
+                         	return;
+                         }                         
                          NSHTTPURLResponse *r = (NSHTTPURLResponse*)response;
                          NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:data
                                                                                     options:kNilOptions

--- a/BaasBox-iOS-SDK/BAAClient.m
+++ b/BaasBox-iOS-SDK/BAAClient.m
@@ -1480,10 +1480,7 @@ NSString* const BAAUserKeyForUserDefaults = @"com.baaxbox.user";
     
     [[self.session dataTaskWithRequest:request
                      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                         if(response == nil){
-                         	failure(error);
-                         	return;
-                         }
+                         
                          NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse*)response;
                          NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:data
                                                                                     options:kNilOptions
@@ -1533,10 +1530,7 @@ NSString* const BAAUserKeyForUserDefaults = @"com.baaxbox.user";
     
 	[[self.session dataTaskWithRequest:request
                      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                         if(response == nil){
-                         	failure(error);
-                         	return;
-                         }                         
+                         
                          NSHTTPURLResponse *r = (NSHTTPURLResponse*)response;
                          NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:data
                                                                                     options:kNilOptions
@@ -1576,10 +1570,7 @@ NSString* const BAAUserKeyForUserDefaults = @"com.baaxbox.user";
                                                  parameters:parameters];
     [[self.session dataTaskWithRequest:request
                      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                         if(response == nil){
-                         	failure(error);
-                         	return;
-                         }                         
+                         
                          NSHTTPURLResponse *r = (NSHTTPURLResponse*)response;
                          NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:data
                                                                                     options:kNilOptions
@@ -1619,10 +1610,7 @@ NSString* const BAAUserKeyForUserDefaults = @"com.baaxbox.user";
                                                  parameters:parameters];
     [[self.session dataTaskWithRequest:request
                      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                         if(response == nil){
-                         	failure(error);
-                         	return;
-                         }                         
+                         
                          NSHTTPURLResponse *r = (NSHTTPURLResponse*)response;
                          NSDictionary *jsonObject = [NSJSONSerialization JSONObjectWithData:data
                                                                                     options:kNilOptions


### PR DESCRIPTION
Added code to check for a valid response before serializing the data. Without this code an exception would be thrown if response is nil, in such cases as the server can not be reached.